### PR TITLE
feat: add whatsapp-like chat bubbles and bluetooth relay location

### DIFF
--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.location.Location
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
@@ -24,6 +25,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.Lifecycle
 import com.bitchat.android.mesh.BluetoothMeshService
+import com.bitchat.android.services.BluetoothRelayLocator
 import com.bitchat.android.onboarding.BluetoothCheckScreen
 import com.bitchat.android.onboarding.BluetoothStatus
 import com.bitchat.android.onboarding.BluetoothStatusManager
@@ -52,9 +54,10 @@ class MainActivity : ComponentActivity() {
     private lateinit var bluetoothStatusManager: BluetoothStatusManager
     private lateinit var locationStatusManager: LocationStatusManager
     private lateinit var batteryOptimizationManager: BatteryOptimizationManager
-    
+
     // Core mesh service - managed at app level
     private lateinit var meshService: BluetoothMeshService
+    private lateinit var relayLocator: BluetoothRelayLocator
     private val mainViewModel: MainViewModel by viewModels()
     private val chatViewModel: ChatViewModel by viewModels { 
         object : ViewModelProvider.Factory {
@@ -78,6 +81,15 @@ class MainActivity : ComponentActivity() {
         permissionManager = PermissionManager(this)
         // Initialize core mesh service first
         meshService = BluetoothMeshService(this)
+        relayLocator = BluetoothRelayLocator(this).apply {
+            // Placeholder relay coordinates - replace with real devices
+            registerRelay(BluetoothRelayLocator.Relay("00:11:22:33:44:55", 37.7749, -122.4194))
+            registerRelay(BluetoothRelayLocator.Relay("66:77:88:99:AA:BB", 37.7750, -122.4183))
+            registerRelay(BluetoothRelayLocator.Relay("CC:DD:EE:FF:00:11", 37.7755, -122.4190))
+            addLocationListener { location: Location ->
+                Log.d("MainActivity", "Relay-based location: ${location.latitude}, ${location.longitude}")
+            }
+        }
         bluetoothStatusManager = BluetoothStatusManager(
             activity = this,
             context = this,
@@ -602,6 +614,7 @@ class MainActivity : ComponentActivity() {
                 // Set up mesh service delegate and start services
                 meshService.delegate = chatViewModel
                 meshService.startServices()
+                relayLocator.startScanning()
                 
                 Log.d("MainActivity", "Mesh service started successfully")
                 
@@ -746,5 +759,6 @@ class MainActivity : ComponentActivity() {
                 Log.w("MainActivity", "Error stopping mesh services in onDestroy: ${e.message}")
             }
         }
+        relayLocator.stopScanning()
     }
 }

--- a/app/src/main/java/com/bitchat/android/services/BluetoothRelayLocator.kt
+++ b/app/src/main/java/com/bitchat/android/services/BluetoothRelayLocator.kt
@@ -1,0 +1,97 @@
+package com.bitchat.android.services
+
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.location.Location
+import android.util.Log
+import androidx.core.content.getSystemService
+import kotlin.math.pow
+
+/**
+ * Simple Bluetooth relay based location provider.
+ *
+ * The service scans for known Bluetooth relays and estimates the
+ * device position based on RSSI derived distances.
+ */
+class BluetoothRelayLocator(private val context: Context) {
+    data class Relay(val mac: String, val latitude: Double, val longitude: Double, val txPower: Int = -59)
+
+    private val bluetoothManager: BluetoothManager? = context.getSystemService()
+    private val scanner: BluetoothLeScanner? = bluetoothManager?.adapter?.bluetoothLeScanner
+
+    private val knownRelays = mutableListOf<Relay>()
+    private val distances = mutableMapOf<String, Double>()
+    private val listeners = mutableListOf<(Location) -> Unit>()
+
+    private val scanCallback = object : ScanCallback() {
+        override fun onScanResult(callbackType: Int, result: ScanResult) {
+            handleResult(result)
+        }
+
+        override fun onBatchScanResults(results: MutableList<ScanResult>) {
+            results.forEach { handleResult(it) }
+        }
+
+        override fun onScanFailed(errorCode: Int) {
+            Log.e(TAG, "Scan failed: $errorCode")
+        }
+    }
+
+    /** Register a relay with known coordinates */
+    fun registerRelay(relay: Relay) {
+        knownRelays += relay
+    }
+
+    /** Add listener for location updates */
+    fun addLocationListener(listener: (Location) -> Unit) {
+        listeners += listener
+    }
+
+    /** Start BLE scanning for registered relays */
+    fun startScanning() {
+        val settings = ScanSettings.Builder()
+            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+            .build()
+        scanner?.startScan(null, settings, scanCallback)
+    }
+
+    /** Stop BLE scanning */
+    fun stopScanning() {
+        scanner?.stopScan(scanCallback)
+    }
+
+    private fun handleResult(result: ScanResult) {
+        val relay = knownRelays.firstOrNull { it.mac.equals(result.device.address, true) } ?: return
+        val distance = calculateDistance(relay.txPower, result.rssi)
+        distances[relay.mac] = distance
+        trilaterate()?.let { location -> listeners.forEach { it(location) } }
+    }
+
+    private fun trilaterate(): Location? {
+        val relays = knownRelays.filter { distances.containsKey(it.mac) }
+        if (relays.size < 3) return null
+        val (r1, r2, r3) = relays.take(3)
+        val d1 = distances[r1.mac]!!
+        val d2 = distances[r2.mac]!!
+        val d3 = distances[r3.mac]!!
+        val x = (r1.longitude / d1 + r2.longitude / d2 + r3.longitude / d3) / (1 / d1 + 1 / d2 + 1 / d3)
+        val y = (r1.latitude / d1 + r2.latitude / d2 + r3.latitude / d3) / (1 / d1 + 1 / d2 + 1 / d3)
+        return Location("bluetooth").apply {
+            latitude = y
+            longitude = x
+        }
+    }
+
+    companion object {
+        private const val TAG = "BluetoothRelayLocator"
+        private const val PROPAGATION_N = 2.0 // free-space path loss constant
+        fun calculateDistance(txPower: Int, rssi: Int): Double {
+            return 10.0.pow((txPower - rssi) / (10 * PROPAGATION_N))
+        }
+    }
+}
+

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -268,12 +268,13 @@ private fun MessageTextWithClickableNicknames(
 }
 
 @Composable
-fun DeliveryStatusIcon(status: DeliveryStatus) {
+fun DeliveryStatusIcon(status: DeliveryStatus, modifier: Modifier = Modifier) {
     val colorScheme = MaterialTheme.colorScheme
-    
+
     when (status) {
         is DeliveryStatus.Sending -> {
             Text(
+                modifier = modifier,
                 text = "○",
                 fontSize = 10.sp,
                 color = colorScheme.primary.copy(alpha = 0.6f)
@@ -282,6 +283,7 @@ fun DeliveryStatusIcon(status: DeliveryStatus) {
         is DeliveryStatus.Sent -> {
             // Use a subtle hollow marker for Sent; single check is reserved for Delivered (iOS parity)
             Text(
+                modifier = modifier,
                 text = "○",
                 fontSize = 10.sp,
                 color = colorScheme.primary.copy(alpha = 0.6f)
@@ -290,6 +292,7 @@ fun DeliveryStatusIcon(status: DeliveryStatus) {
         is DeliveryStatus.Delivered -> {
             // Single check for Delivered (matches iOS expectations)
             Text(
+                modifier = modifier,
                 text = "✓",
                 fontSize = 10.sp,
                 color = colorScheme.primary.copy(alpha = 0.8f)
@@ -297,6 +300,7 @@ fun DeliveryStatusIcon(status: DeliveryStatus) {
         }
         is DeliveryStatus.Read -> {
             Text(
+                modifier = modifier,
                 text = "✓✓",
                 fontSize = 10.sp,
                 color = Color(0xFF007AFF), // Blue
@@ -305,6 +309,7 @@ fun DeliveryStatusIcon(status: DeliveryStatus) {
         }
         is DeliveryStatus.Failed -> {
             Text(
+                modifier = modifier,
                 text = "⚠",
                 fontSize = 10.sp,
                 color = Color.Red.copy(alpha = 0.8f)
@@ -312,6 +317,7 @@ fun DeliveryStatusIcon(status: DeliveryStatus) {
         }
         is DeliveryStatus.PartiallyDelivered -> {
             Text(
+                modifier = modifier,
                 text = "✓${status.reached}/${status.total}",
                 fontSize = 10.sp,
                 color = colorScheme.primary.copy(alpha = 0.6f)

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -118,36 +119,44 @@ fun MessageItem(
 ) {
     val colorScheme = MaterialTheme.colorScheme
     val timeFormatter = remember { SimpleDateFormat("HH:mm:ss", Locale.getDefault()) }
-    
+    val isSelf = message.senderPeerID == meshService.myPeerID ||
+                 message.sender == currentUserNickname ||
+                 message.sender.startsWith("$currentUserNickname#")
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(0.dp)
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.Top
+            horizontalArrangement = if (isSelf) Arrangement.End else Arrangement.Start,
+            verticalAlignment = Alignment.Bottom
         ) {
-            // Create a custom layout that combines selectable text with clickable nickname areas
-            MessageTextWithClickableNicknames(
-                message = message,
-                currentUserNickname = currentUserNickname,
-                meshService = meshService,
-                colorScheme = colorScheme,
-                timeFormatter = timeFormatter,
-                onNicknameClick = onNicknameClick,
-                onMessageLongPress = onMessageLongPress,
-                modifier = Modifier.weight(1f)
-            )
-            
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = if (isSelf) Color(0xFFE7FFDB) else Color.White,
+                tonalElevation = 1.dp
+            ) {
+                MessageTextWithClickableNicknames(
+                    message = message,
+                    currentUserNickname = currentUserNickname,
+                    meshService = meshService,
+                    colorScheme = colorScheme,
+                    timeFormatter = timeFormatter,
+                    onNicknameClick = onNicknameClick,
+                    onMessageLongPress = onMessageLongPress,
+                    modifier = Modifier.padding(8.dp)
+                )
+            }
+
             // Delivery status for private messages
-            if (message.isPrivate && message.sender == currentUserNickname) {
+            if (message.isPrivate && isSelf) {
                 message.deliveryStatus?.let { status ->
-                    DeliveryStatusIcon(status = status)
+                    DeliveryStatusIcon(status = status, modifier = Modifier.padding(start = 4.dp, bottom = 2.dp))
                 }
             }
         }
-        
+
         // Link preview pills for URLs in message content
         if (message.sender != "system") {
             val urls = URLDetector.extractUrls(message.content)

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,2 @@
+# Dieser Wert wird automatisch generiert oder kann manuell gesetzt werden
+sdk.dir=C\:\\Users\\Nizar\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
## Summary
- style chat messages with WhatsApp-like left/right bubbles
- introduce BluetoothRelayLocator to estimate location from nearby relays
- start relay scanning during app initialization

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae49fe9cc88325b11c762af2f0ecde